### PR TITLE
Update jsub distro and general cleanup

### DIFF
--- a/public_html/cache.php
+++ b/public_html/cache.php
@@ -61,7 +61,7 @@ if (!is_readable($c))
     $fullfile = 'https://commons.wikimedia.org/w/thumb.php?w=' . $thumb_width . '&f=' . $file_name;
 
   // either not cached before, or cached version too old
-  ini_set('user_agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');
+  ini_set('user_agent', 'panoviewer/1.0 (https://panoviewer.toolforge.org/)');
 
   // if we are not getting a thumbnail make sure the file is a valid JPG file
   if ($thumb_width == '')

--- a/public_html/cache.php
+++ b/public_html/cache.php
@@ -1,13 +1,13 @@
 <?php
 // https://commons.wikimedia.org/w/thumb.php?w=48&f=Harding%20Icefield%201.jpg
 
-$f = str_replace(' ', '_', ucfirst($_GET['f']));
+$file_name = str_replace(' ', '_', ucfirst($_GET['f']));
 if (array_key_exists('t', $_GET))
-  $t = intval($_GET['t']);
+  $thumb_width = intval($_GET['t']);
 else
-  $t = '';
+  $thumb_width = '';
 
-if ($f == "")
+if ($file_name == "")
 {
   echo "Supply a filename!";
   exit;
@@ -20,7 +20,7 @@ $db = mysqli_connect("p:commonswiki.labsdb", $ts_mycnf['user'], $ts_mycnf['passw
 unset($ts_mycnf, $ts_pw);
 
 // get last upload date and image dimensions from database
-$sql = sprintf("SELECT img_timestamp, img_width, img_height FROM image WHERE img_name = '%s'", mysqli_real_escape_string($db, $f));
+$sql = sprintf("SELECT img_timestamp, img_width, img_height FROM image WHERE img_name = '%s'", mysqli_real_escape_string($db, $file_name));
 $res = mysqli_query($db, $sql);
 
 if (mysqli_num_rows($res) == 1)
@@ -29,7 +29,7 @@ if (mysqli_num_rows($res) == 1)
 
   // do not fetch a thumbnail if the full image is already smaller than the
   // requested size
-  if (intval($row['img_width']) < $t) $t = '';
+  if (intval($row['img_width']) < $thumb_width) $thumb_width = '';
 }
 else
 {
@@ -37,8 +37,8 @@ else
   exit;
 }
 
-$c = 'cache/' . md5($f . $t) . '.jpg';
-$md5 = md5($f);
+$c = 'cache/' . md5($file_name . $thumb_width) . '.jpg';
+$md5 = md5($file_name);
 
 
 $fetch_file = false;
@@ -55,16 +55,16 @@ else
 
 if (!is_readable($c))
 {
-  if ($t == '')
-    $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5,0,1) . '/' . substr($md5,0,2) . '/' . $f;
+  if ($thumb_width == '')
+    $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5,0,1) . '/' . substr($md5,0,2) . '/' . $file_name;
   else
-    $fullfile = 'https://commons.wikimedia.org/w/thumb.php?w=' . $t . '&f=' . $f;
+    $fullfile = 'https://commons.wikimedia.org/w/thumb.php?w=' . $thumb_width . '&f=' . $file_name;
 
   // either not cached before, or cached version too old
   ini_set('user_agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');
 
   // if we are not getting a thumbnail make sure the file is a valid JPG file
-  if ($t == '')
+  if ($thumb_width == '')
   {
     $image = file_get_contents($fullfile, false, null, 0, 100);
 

--- a/public_html/config.php
+++ b/public_html/config.php
@@ -61,7 +61,7 @@ if (!array_key_exists('p', $_GET))
   if ($fetch_file)
   {
     // either not cached before, or cached version too old
-    ini_set('user_agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');
+    ini_set('user_agent', 'panoviewer/1.0 (https://panoviewer.toolforge.org/)');
 
     // make sure the file is a valid JPG file
     $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5, 0, 1) . '/' . substr($md5, 0, 2) . '/' . urlencode($file_name);

--- a/public_html/config.php
+++ b/public_html/config.php
@@ -82,7 +82,7 @@ if (!array_key_exists('p', $_GET))
     if ($width > $max_width)
     {
       $preview = 'https://commons.wikimedia.org/w/thumb.php?w=' . $max_width . '&f=' . urlencode($file_name);
-      $command = 'jsub -mem 2048m -l release=trusty -N ' . escapeshellarg('pano_' . $md5) . ' -once ./multires.sh cache/ ' . escapeshellarg($md5) . ' ' . escapeshellarg(urlencode($file_name));
+      $command = 'jsub -mem 2048m -N ' . escapeshellarg('pano_' . $md5) . ' -once ./multires.sh cache/ ' . escapeshellarg($md5) . ' ' . escapeshellarg(urlencode($file_name));
       exec ($command, $out, $ret);
     }
     else

--- a/public_html/config.php
+++ b/public_html/config.php
@@ -10,7 +10,7 @@ header("Expires: 0");
 
 // get normalized filename
 if (array_key_exists('f', $_GET))
-  $file_name = str_replace(' ', '_', ucfirst(urldecode($_GET['f'])));
+  $file_name = str_replace(' ', '_', ucfirst($_GET['f']));
 else {
   echo '{ "error": "No file name supplied" }';
   exit;

--- a/public_html/config.php
+++ b/public_html/config.php
@@ -10,14 +10,14 @@ header("Expires: 0");
 
 // get normalized filename
 if (array_key_exists('f', $_GET))
-  $f = str_replace(' ', '_', ucfirst(urldecode($_GET['f'])));
+  $file_name = str_replace(' ', '_', ucfirst(urldecode($_GET['f'])));
 else {
   echo '{ "error": "No file name supplied" }';
   exit;
 }
 
 // cache identifier
-$md5 = md5($f);
+$md5 = md5($file_name);
 $cache_prefix = 'cache/' . $md5;
 $cache_file = $cache_prefix . '.jpg';
 
@@ -31,7 +31,7 @@ if (!array_key_exists('p', $_GET))
   unset($ts_mycnf, $ts_pw);
 
   // get last upload date and image dimensions from database
-  $sql = sprintf("SELECT img_timestamp, img_width, img_height FROM image WHERE img_name = '%s'", mysqli_real_escape_string($db, $f));
+  $sql = sprintf("SELECT img_timestamp, img_width, img_height FROM image WHERE img_name = '%s'", mysqli_real_escape_string($db, $file_name));
   $res = mysqli_query($db, $sql);
 
   if (mysqli_num_rows($res) != 1)
@@ -64,7 +64,7 @@ if (!array_key_exists('p', $_GET))
     ini_set('user_agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');
 
     // make sure the file is a valid JPG file
-    $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5, 0, 1) . '/' . substr($md5, 0, 2) . '/' . urlencode($f);
+    $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5, 0, 1) . '/' . substr($md5, 0, 2) . '/' . urlencode($file_name);
     $image = file_get_contents($fullfile, false, null, 0, 100);
     if (substr($image, 6, 4)  != 'JFIF' &&
         substr($image, 6, 4)  != 'Exif' &&
@@ -81,8 +81,8 @@ if (!array_key_exists('p', $_GET))
     // for large images we prepare a downscaled preview while the tiling is in progress
     if ($width > $max_width)
     {
-      $preview = 'https://commons.wikimedia.org/w/thumb.php?w=' . $max_width . '&f=' . urlencode($f);
-      $command = 'jsub -mem 2048m -l release=trusty -N ' . escapeshellarg('pano_' . $md5) . ' -once ./multires.sh cache/ ' . escapeshellarg($md5) . ' ' . escapeshellarg(urlencode($f));
+      $preview = 'https://commons.wikimedia.org/w/thumb.php?w=' . $max_width . '&f=' . urlencode($file_name);
+      $command = 'jsub -mem 2048m -l release=trusty -N ' . escapeshellarg('pano_' . $md5) . ' -once ./multires.sh cache/ ' . escapeshellarg($md5) . ' ' . escapeshellarg(urlencode($file_name));
       exec ($command, $out, $ret);
     }
     else

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -74,7 +74,7 @@ function recheck()
       $(window).off('blur.multires_poll');
       clearTimeout(handler);
       handler = null;
-    } else {
+    } else if (data.multires_pending) {
       handler = setTimeout(recheck, 5000);
     }
   }

--- a/public_html/multires.php
+++ b/public_html/multires.php
@@ -1,12 +1,12 @@
 <?php
 
-$f = str_replace(' ', '_', ucfirst($_GET['f']));
+$file_name = str_replace(' ', '_', ucfirst($_GET['f']));
 if (array_key_exists('t', $_GET))
-  $t = intval($_GET['t']);
+  $thumb_width = intval($_GET['t']);
 else
-  $t = '';
+  $thumb_width = '';
 
-if ($f == "")
+if ($file_name == "")
 {
   echo "Supply a filename!";
   exit;
@@ -19,7 +19,7 @@ $db = mysqli_connect("p:commonswiki.labsdb", $ts_mycnf['user'], $ts_mycnf['passw
 unset($ts_mycnf, $ts_pw);
 
 // get last upload date and image dimensions from database
-$sql = sprintf("SELECT img_timestamp, img_width, img_height FROM image WHERE img_name = '%s'", mysqli_real_escape_string($db, $f));
+$sql = sprintf("SELECT img_timestamp, img_width, img_height FROM image WHERE img_name = '%s'", mysqli_real_escape_string($db, $file_name));
 $res = mysqli_query($db, $sql);
 
 if (mysqli_num_rows($res) == 1)
@@ -28,7 +28,7 @@ if (mysqli_num_rows($res) == 1)
 
   // do not fetch a thumbnail if the full image is already smaller than the
   // requested size
-  if (intval($row['img_width']) < $t) $t = '';
+  if (intval($row['img_width']) < $thumb_width) $thumb_width = '';
 }
 else
 {
@@ -37,7 +37,7 @@ else
 }
 
 
-$md5 = md5($f);
+$md5 = md5($file_name);
 $dir = 'cache/' . $md5;
 $tmp = $dir . '.jpg';
 $cfg = $dir . '/config.json';
@@ -56,7 +56,7 @@ else
 
 if ($update_cache)
 {
-  $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5,0,1) . '/' . substr($md5,0,2) . '/' . $f;
+  $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5,0,1) . '/' . substr($md5,0,2) . '/' . $file_name;
 
   // either not cached before, or cached version too old
   ini_set('user_agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');

--- a/public_html/multires.php
+++ b/public_html/multires.php
@@ -59,7 +59,7 @@ if ($update_cache)
   $fullfile = 'https://upload.wikimedia.org/wikipedia/commons/' . substr($md5,0,1) . '/' . substr($md5,0,2) . '/' . $file_name;
 
   // either not cached before, or cached version too old
-  ini_set('user_agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');
+  ini_set('user_agent', 'panoviewer/1.0 (https://panoviewer.toolforge.org/)');
 
   // if we are not getting a thumbnail make sure the file is a valid JPG file
   $image = file_get_contents($fullfile, false, null, 0, 100);


### PR DESCRIPTION
- Rename single-letter variable names
- Don't use a fake browser User-Agent
- Fix notice "Undefined variable: width" in p=1 mode
- Don't continually check for multires output if we're not generating it
- Don't call urldecode() on data from $_GET
- Stop requiring trusty
